### PR TITLE
Don't rename variables that are assigned later

### DIFF
--- a/integrationtests/testdata/testfile.go
+++ b/integrationtests/testdata/testfile.go
@@ -99,6 +99,96 @@ func variableIsMinusAssigned() {
 	}
 }
 
+func variableIsMultiplyAssigned() {
+	for i, v := range []int{1, 2, 3} {
+		index, variable := i, v
+
+		index *= 123
+
+		fmt.Println(index, variable)
+	}
+}
+
+func variableIsDivideAssigned() {
+	for i, v := range []int{1, 2, 3} {
+		index, variable := i, v
+
+		index /= 123
+
+		fmt.Println(index, variable)
+	}
+}
+
+func variableIsModuloAssigned() {
+	for i, v := range []int{1, 2, 3} {
+		index, variable := i, v
+
+		index %= 123
+
+		fmt.Println(index, variable)
+	}
+}
+
+func variableIsAndAssigned() {
+	for i, v := range []int{1, 2, 3} {
+		index, variable := i, v
+
+		index &= 123
+
+		fmt.Println(index, variable)
+	}
+}
+
+func variableIsOrAssigned() {
+	for i, v := range []int{1, 2, 3} {
+		index, variable := i, v
+
+		index |= 123
+
+		fmt.Println(index, variable)
+	}
+}
+
+func variableIsXorAssigned() {
+	for i, v := range []int{1, 2, 3} {
+		index, variable := i, v
+
+		index ^= 123
+
+		fmt.Println(index, variable)
+	}
+}
+
+func variableIsShiftLeftAssigned() {
+	for i, v := range []int{1, 2, 3} {
+		index, variable := i, v
+
+		index <<= 123
+
+		fmt.Println(index, variable)
+	}
+}
+
+func variableIsShiftRightAssigned() {
+	for i, v := range []int{1, 2, 3} {
+		index, variable := i, v
+
+		index >>= 123
+
+		fmt.Println(index, variable)
+	}
+}
+
+func variableIsAndNotAssigned() {
+	for i, v := range []int{1, 2, 3} {
+		index, variable := i, v
+
+		index &^= 123
+
+		fmt.Println(index, variable)
+	}
+}
+
 func variableIsSimplyAssigned() {
 	for i, v := range []int{1, 2, 3} {
 		assigned, variable := i, v

--- a/integrationtests/testdata/testfile.go
+++ b/integrationtests/testdata/testfile.go
@@ -59,6 +59,56 @@ func trickyMultiAssign2() {
 	}
 }
 
+func variableIsIncrementedLater() {
+	for i, v := range []int{1, 2, 3} {
+		incrementing, variable := i, v
+
+		incrementing++
+
+		fmt.Println(incrementing, variable)
+	}
+}
+
+func variableIsDecrementedLater() {
+	for i, v := range []int{1, 2, 3} {
+		decrementing, variable := i, v
+
+		decrementing--
+
+		fmt.Println(decrementing, variable)
+	}
+}
+
+func variableIsPlusAssigned() {
+	for i, v := range []int{1, 2, 3} {
+		incrementing, variable := i, v
+
+		incrementing += 123
+
+		fmt.Println(incrementing, variable)
+	}
+}
+
+func variableIsMinusAssigned() {
+	for i, v := range []int{1, 2, 3} {
+		decrementing, variable := i, v
+
+		decrementing -= 123
+
+		fmt.Println(decrementing, variable)
+	}
+}
+
+func variableIsSimplyAssigned() {
+	for i, v := range []int{1, 2, 3} {
+		assigned, variable := i, v
+
+		assigned = 123
+
+		fmt.Println(assigned, variable)
+	}
+}
+
 func wasABugBeforeGo122() {
 	for i, v := range []int{1, 2, 3} {
 		go func() {

--- a/integrationtests/testdata/testfile_exp.go
+++ b/integrationtests/testdata/testfile_exp.go
@@ -92,6 +92,96 @@ func variableIsMinusAssigned() {
 	}
 }
 
+func variableIsMultiplyAssigned() {
+	for i, v := range []int{1, 2, 3} {
+		index := i
+
+		index *= 123
+
+		fmt.Println(index, v)
+	}
+}
+
+func variableIsDivideAssigned() {
+	for i, v := range []int{1, 2, 3} {
+		index := i
+
+		index /= 123
+
+		fmt.Println(index, v)
+	}
+}
+
+func variableIsModuloAssigned() {
+	for i, v := range []int{1, 2, 3} {
+		index := i
+
+		index %= 123
+
+		fmt.Println(index, v)
+	}
+}
+
+func variableIsAndAssigned() {
+	for i, v := range []int{1, 2, 3} {
+		index := i
+
+		index &= 123
+
+		fmt.Println(index, v)
+	}
+}
+
+func variableIsOrAssigned() {
+	for i, v := range []int{1, 2, 3} {
+		index := i
+
+		index |= 123
+
+		fmt.Println(index, v)
+	}
+}
+
+func variableIsXorAssigned() {
+	for i, v := range []int{1, 2, 3} {
+		index := i
+
+		index ^= 123
+
+		fmt.Println(index, v)
+	}
+}
+
+func variableIsShiftLeftAssigned() {
+	for i, v := range []int{1, 2, 3} {
+		index := i
+
+		index <<= 123
+
+		fmt.Println(index, v)
+	}
+}
+
+func variableIsShiftRightAssigned() {
+	for i, v := range []int{1, 2, 3} {
+		index := i
+
+		index >>= 123
+
+		fmt.Println(index, v)
+	}
+}
+
+func variableIsAndNotAssigned() {
+	for i, v := range []int{1, 2, 3} {
+		index := i
+
+		index &^= 123
+
+		fmt.Println(index, v)
+	}
+}
+
 func variableIsSimplyAssigned() {
 	for i, v := range []int{1, 2, 3} {
 		assigned := i

--- a/integrationtests/testdata/testfile_exp.go
+++ b/integrationtests/testdata/testfile_exp.go
@@ -52,6 +52,56 @@ func trickyMultiAssign2() {
 	}
 }
 
+func variableIsIncrementedLater() {
+	for i, v := range []int{1, 2, 3} {
+		incrementing := i
+
+		incrementing++
+
+		fmt.Println(incrementing, v)
+	}
+}
+
+func variableIsDecrementedLater() {
+	for i, v := range []int{1, 2, 3} {
+		decrementing := i
+
+		decrementing--
+
+		fmt.Println(decrementing, v)
+	}
+}
+
+func variableIsPlusAssigned() {
+	for i, v := range []int{1, 2, 3} {
+		incrementing := i
+
+		incrementing += 123
+
+		fmt.Println(incrementing, v)
+	}
+}
+
+func variableIsMinusAssigned() {
+	for i, v := range []int{1, 2, 3} {
+		decrementing := i
+
+		decrementing -= 123
+
+		fmt.Println(decrementing, v)
+	}
+}
+
+func variableIsSimplyAssigned() {
+	for i, v := range []int{1, 2, 3} {
+		assigned := i
+
+		assigned = 123
+
+		fmt.Println(assigned, v)
+	}
+}
+
 func wasABugBeforeGo122() {
 	for i, v := range []int{1, 2, 3} {
 		go func() {

--- a/main.go
+++ b/main.go
@@ -45,7 +45,7 @@ func run(p *analysis.Pass) (any, error) {
 					panic(`dev error: should not encounter a shadowed assignment at the end of the list`)
 				}
 
-				r.handleAssignment(assn, nextPos)
+				r.handleAssignment(f.Body.List[i+1:], assn, nextPos)
 				continue
 			}
 
@@ -127,7 +127,7 @@ func (r *replacer) handleIdent(ident *ast.Ident) {
 	r.diagsByVar[ident.Name] = diag
 }
 
-func (r *replacer) handleAssignment(a *ast.AssignStmt, nextPos token.Pos) error {
+func (r *replacer) handleAssignment(restOfLoop []ast.Stmt, a *ast.AssignStmt, nextPos token.Pos) error {
 	var newLhs, newRhs []ast.Expr
 
 	// Preemptively assign this in case we need it :pokerface:
@@ -172,6 +172,15 @@ func (r *replacer) handleAssignment(a *ast.AssignStmt, nextPos token.Pos) error 
 		lhsIdent, ok := lhs.(*ast.Ident)
 		if !ok {
 			// Somehow we don't have an identifier on the left-hand side.
+			continue
+		}
+
+		// We have a loop variable being assigned to a different identifier. One last check: we have
+		// to make sure that the new binding is never assigned to. If it is, we should keep the
+		// assignment.
+		if isMutated(restOfLoop, lhsIdent) {
+			newLhs = append(newLhs, lhs)
+			newRhs = append(newRhs, rhs)
 			continue
 		}
 
@@ -231,10 +240,60 @@ func (r *replacer) handleAssignment(a *ast.AssignStmt, nextPos token.Pos) error 
 	return nil
 }
 
-func isUnderscoreIdent(n ast.Node) bool {
+func isMutated(stmts []ast.Stmt, ident *ast.Ident) (mut bool) {
+	for _, stmt := range stmts {
+		foundMutation := false
+		ast.Inspect(stmt, func(n ast.Node) bool {
+			switch tn := n.(type) {
+			case *ast.IncDecStmt:
+				if isMatchingIdent(tn.X, ident) {
+					foundMutation = true
+					return false
+				}
+			case *ast.AssignStmt:
+				switch tn.Tok {
+				case token.ADD_ASSIGN,
+					token.SUB_ASSIGN,
+					token.MUL_ASSIGN,
+					token.QUO_ASSIGN,
+					token.REM_ASSIGN,
+					token.AND_ASSIGN,
+					token.OR_ASSIGN,
+					token.XOR_ASSIGN,
+					token.SHL_ASSIGN,
+					token.SHR_ASSIGN,
+					token.AND_NOT_ASSIGN:
+
+					for _, lhs := range tn.Lhs {
+						if isMatchingIdent(lhs, ident) {
+							foundMutation = true
+							return false
+						}
+					}
+				default:
+					return true
+				}
+			}
+
+			return true
+		})
+		if foundMutation {
+			return true
+		}
+	}
+	return false
+}
+
+func isMatchingIdent(n ast.Node, exp *ast.Ident) bool {
 	if n == nil {
 		return false
 	}
 	ident, ok := n.(*ast.Ident)
-	return ok && ident.Name == `_`
+	return ok && ident.Name == exp.Name
+}
+
+func isUnderscoreIdent(n ast.Node) bool {
+	return isMatchingIdent(n, &ast.Ident{
+		Name: `_`,
+	})
 }

--- a/main.go
+++ b/main.go
@@ -252,7 +252,8 @@ func isMutated(stmts []ast.Stmt, ident *ast.Ident) (mut bool) {
 				}
 			case *ast.AssignStmt:
 				switch tn.Tok {
-				case token.ADD_ASSIGN,
+				case token.ASSIGN,
+					token.ADD_ASSIGN,
 					token.SUB_ASSIGN,
 					token.MUL_ASSIGN,
 					token.QUO_ASSIGN,


### PR DESCRIPTION
Consider the following loop:

```go
for i, v := range []int{1, 2, 3} {
     index, variable := i, v
     index++
     fmt.Println(index, variable)
}
```

Currently, we'd transform it to the following:

```go
for i, v := range []int{1, 2, 3} {
     i++
     fmt.Println(i, v)
}
```

However, it's probably not considered better to remove the assignment and initialization of `index` in this case. Instead, with this PR, we'll instead transform the loop to the following:

```go
for i, v := range []int{1, 2, 3} {
     index := i
     index++
     fmt.Println(index, v)
}
```